### PR TITLE
The memoizing stemmer breaks on the word 'constructor'

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {"name": "porter-stemmer",
  "description": "Martin Porter's stemmer wrapped in CommonJS for use in node.js",
- "version": "0.9.1", 
+ "version": "0.9.2", 
 
  "authors": ["Jed Parsons <jed@jedparsons.com> (http://jedparsons.com)",
              "Christoper McKenzie <cmckenzie@iizuu.com> (http://qaa.ath.cx/porter_js_demo.html",

--- a/porter.js
+++ b/porter.js
@@ -187,7 +187,7 @@
   }
 
   // memoize at the module level
-  var memo = {};
+  var memo = Object.create(null);
   var memoizingStemmer = function(w) {
     if (!memo[w]) {
       memo[w] = stemmer(w);

--- a/test/input.txt
+++ b/test/input.txt
@@ -4355,6 +4355,7 @@ constrains
 constraint
 constring
 construction
+constructor
 construe
 consul
 consuls

--- a/test/memoizing_stemmer_vows.js
+++ b/test/memoizing_stemmer_vows.js
@@ -25,6 +25,14 @@ vows.describe('The memoizing stemmer')
         assert(results[0] === results[1]);
       }
     }
+  },
+  "passes Dr Porter's test": function() {
+    var vocabulary = fs.readFileSync('./input.txt').toString().trim().split('\n');
+    var expected = fs.readFileSync('./output.txt').toString().trim().split('\n');
+
+    for (var i=0; i<vocabulary.length; i++) {
+      assert(memoizingStemmer(vocabulary[i]) === expected[i]);
+    }
   }
 })
 

--- a/test/output.txt
+++ b/test/output.txt
@@ -4355,6 +4355,7 @@ constrain
 constraint
 constr
 construct
+constructor
 constru
 consul
 consul


### PR DESCRIPTION
I added a failing test case in 2f7dee2c429a224de95c276805973bb09d9d9c3b and the fix in e86373f1575e8ed558e5c36a17a400025c431e7d.
It's just replacing
```var memo = {};```
with
```var memo = Object.create(null);```